### PR TITLE
Fix auth-json when an empty string is passed and increase ssh retry

### DIFF
--- a/cli/utils/common.py
+++ b/cli/utils/common.py
@@ -132,7 +132,7 @@ def ssh_to_partition(config):
     ip = util.get_ip_address(config)
     username = util.get_ssh_username(config)
     ssh_key = util.get_ssh_priv_key(config)
-    for i in range(30):
+    for i in range(50):
         scp_port = 22
         client = get_ssh_client()
         try:
@@ -140,11 +140,11 @@ def ssh_to_partition(config):
                            key_filename=ssh_key, timeout=10)
             break
         except Exception as e:
-            if i == 29:
+            if i == 49:
                 logger.error(
-                    f"failed to establish SSH connection to partition after 30 retries, error: {e}")
+                    f"failed to establish SSH connection to partition after 50 retries, error: {e}")
                 raise paramiko.SSHException(
-                    f"failed to establish SSH connection to partition after 30 retries, error: {e}")
+                    f"failed to establish SSH connection to partition after 50 retries, error: {e}")
             logger.debug("Not able to SSH to the partition yet, retrying..")
             time.sleep(10)
     return client

--- a/cli/utils/iso_util.py
+++ b/cli/utils/iso_util.py
@@ -47,7 +47,7 @@ def generate_cloud_init_iso_config(config, slot_num, config_dir):
         config_dir + "/99_custom_network.cfg", "w")
     network_config_file.write(network_config_output)
 
-    auth_json = config["ai"]["auth-json"]
+    auth_json = "{}" if config["ai"]["auth-json"] == "" else config["ai"]["auth-json"]
     auth_config_file = open(config_dir + "/auth.json", "w")
     auth_config_file.write(auth_json)
     logger.debug("Generated config files for the cloud-init ISO")


### PR DESCRIPTION
SSH retry was required when booting it with fedora base bootc image, it took little more longer than to boot than rhel image. 
