### PR TITLE
Fix bugs found during testing in new dual VIOS setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,7 +157,7 @@ cloud-init-iso/config
 
 # iso files will be stored here
 iso
-
+update-iso
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To get started, you can follow steps below to build and deploy a simple entity e
         - Scripts and README to build the AI image are given [here](examples/simple-entity-extraction/README.md), ensure that you use the vLLM AI image created in the previous step as base image(FROM) here.
 ### Deployer steps
 - **Step 1: Set up PIM**
-    - You can follow the steps to set up PIM on your IBMi/Linux machine given [here](docs/deployer-guide.md#installation).
+    - You can follow the steps to set up PIM on your IBMi/Linux machine given [here](docs/deployer-guide.md#installation) and please go over the [Prerequisites](docs/deployer-guide.md#prerequisites) section here before deploying a AI partition.
 - **Step 2: Configure your AI partition**
     - Read through this [guide](docs/configuration-guide.md) and fill appropriate values in [config.ini](config.ini).
     - Use final image built on builder step 4 in `ai.image` field.

--- a/cli/cmd/launch.py
+++ b/cli/cmd/launch.py
@@ -106,21 +106,28 @@ def _launch(config, cookies, sys_uuid, vios_uuids):
         b_scsi_exists, _, _ = command_util.check_if_scsi_mapping_exist(
             partition_uuid, vios_payload, vopt_bootstrap)
         if not b_scsi_exists:
+            logger.debug(f"Bootstrap ISO not attached to the partition yet. attaching it")
             if vios_cloudinit_media_uuid == vios_bootstrap_media_uuid:
+                logger.debug(f"Attaching both bootstrap and cloud init ISOs to the partition")
                 vopt.attach_vopt(vios_payload, config, cookies,
                                  partition_uuid, sys_uuid, vios_bootstrap_media_uuid, "")
                 cloud_init_attached = True
+                logger.debug("Attached both bootstrap and cloud init ISO to the partition")
             else:
                 vopt.attach_vopt(vios_payload, config, cookies, partition_uuid,
                                  sys_uuid, vios_bootstrap_media_uuid, vopt_bootstrap)
+                logger.debug("Attached bootstrap ISO to the partition")
         if not cloud_init_attached:
+            logger.debug("Cloud init ISO not attached along with the bootstrap ISO")
             vios_cloudinit_payload = vios_operation.get_vios_details(
                 config, cookies, sys_uuid, vios_cloudinit_media_uuid)
             c_scsi_exists, _, _ = command_util.check_if_scsi_mapping_exist(
                 partition_uuid, vios_cloudinit_payload, vopt_cloud_init)
             if not c_scsi_exists:
+                logger.debug("Cloud init ISO not attached to the partition yet, attaching it")
                 vopt.attach_vopt(vios_cloudinit_payload, config, cookies, partition_uuid,
                                  sys_uuid, vios_cloudinit_media_uuid, vopt_cloud_init)
+                logger.debug("Attached cloud init ISO to the partition")
 
         logger.info("Installation ISOs attached to the partition")
 

--- a/cli/cmd/update_config.py
+++ b/cli/cmd/update_config.py
@@ -60,7 +60,7 @@ def _update_config(config, cookies, sys_uuid, vios_uuid_list):
             shutil.rmtree(common.cloud_init_update_config_dir)
             return
         logger.info("Detected config change, updating")
-        iso_util.generate_cloud_init_iso_file(common.cloud_init_update_config_dir, config, common.cloud_init_update_config_dir)
+        iso_util.generate_cloud_init_iso_file(common.update_iso_dir, config, common.cloud_init_update_config_dir)
 
         logger.info("Shutting down the partition")
         activation.shutdown_partition(config, cookies, partition_uuid)
@@ -68,7 +68,7 @@ def _update_config(config, cookies, sys_uuid, vios_uuid_list):
 
         cloud_init_iso = util.get_cloud_init_iso(config)
         logger.info("Uploading the new cloud init with the config changes")
-        vios_cloudinit_media_uuid = iso_util.upload_iso_to_media_repository(config, cookies, common.cloud_init_update_config_dir, cloud_init_iso, sys_uuid, vios_uuid_list)
+        vios_cloudinit_media_uuid = iso_util.upload_iso_to_media_repository(config, cookies, common.update_iso_dir, cloud_init_iso, sys_uuid, vios_uuid_list)
         logger.debug("Cloud init uploaded")
         
         logger.info("Attaching the cloud init to the partition")
@@ -84,7 +84,7 @@ def _update_config(config, cookies, sys_uuid, vios_uuid_list):
         monitor_util.monitor_pim(config)
 
         # Move used cloud init iso to iso dir
-        shutil.move(f"{common.cloud_init_update_config_dir}/{cloud_init_iso}", f"{common.iso_dir}/{cloud_init_iso}")
+        shutil.move(f"{common.update_iso_dir}/{cloud_init_iso}", f"{common.iso_dir}/{cloud_init_iso}")
         
         # Cleanup existing config and move updated config
         shutil.rmtree(common.cloud_init_config_dir)

--- a/cli/cmd/upgrade.py
+++ b/cli/cmd/upgrade.py
@@ -38,7 +38,7 @@ def _upgrade(config):
         ssh_client = common.ssh_to_partition(config)
 
         logger.info(f"Updating PIM partition's '{bootc_auth_json}' with the latest one provided")
-        auth_json = util.get_auth_json(config)
+        auth_json = "{}" if util.get_auth_json(config) == "" else util.get_auth_json(config)
         sftp_client = ssh_client.open_sftp()
         with sftp_client.open("/tmp/auth.json", 'w') as f:
             f.write(auth_json)

--- a/cli/utils/command_util.py
+++ b/cli/utils/command_util.py
@@ -63,7 +63,7 @@ def remove_vopt_device(config, cookies, vios, vopt_name):
 
         if not found:
             logger.debug(f"vOPT device '{vopt_name}' is not present in media repository")
-            return
+            return False
 
         headers = {"x-api-key": util.get_session_key(
             config), "Content-Type": "application/vnd.ibm.powervm.uom+xml; type=VolumeGroup"}
@@ -73,13 +73,13 @@ def remove_vopt_device(config, cookies, vios, vopt_name):
         if response.status_code != 200:
             logger.error(
                 f"failed to update volume group after deleting vOPT device from media repository, error: {response.text}")
-            return
+            return False
 
         logger.debug(
             f"Virtual optical media '{vopt_name}' has been deleted successfully")
     except Exception as e:
         raise e
-    return
+    return True
 
 
 def remove_virtual_disk(config, cookies, vios_uuid, vg_id, vdisk_name):

--- a/cli/utils/common.py
+++ b/cli/utils/common.py
@@ -21,6 +21,7 @@ clidir = getclidir()
 PARTITION_FLAVOR_DIR = f"{clidir}/partition-flavor"
 keys_path = clidir + "/keys"
 iso_dir = clidir + "/iso"
+update_iso_dir = clidir + "/update-iso"
 cloud_init_config_dir =  clidir + "/cloud-init-iso/config"
 cloud_init_update_config_dir =  clidir + "/cloud-init-iso/update-config"
 

--- a/cli/utils/string_util.py
+++ b/cli/utils/string_util.py
@@ -23,7 +23,7 @@ def get_bootstrap_iso(config):
     return hashlib.sha256(get_bootstrap_iso_download_url(config).encode()).hexdigest()[:32] + "_pimb"
 
 def get_cloud_init_iso(config):
-    return get_partition_name(config).lower() + "_pimc"
+    return hashlib.sha256(get_partition_name(config).encode()).hexdigest()[:32] + "_pimc"
 
 # partition related Getters
 def get_desired_memory(config):

--- a/cli/utils/validator.py
+++ b/cli/utils/validator.py
@@ -8,7 +8,7 @@ from cli.utils.common import *
 from cli.utils.string_util import *
 
 logger = get_logger("validator")
-supported_versions = ["FW1110.00", "FW1050.50"]
+supported_versions = ["1110.01", "1110.00", "1060.51", "1060.50", "1050.51",  "1050.50"]
 
 def validate_config(config):
     is_mandatory_param_valid = validate_mandatory_params(config)
@@ -174,7 +174,7 @@ def validate_prefix_length(config):
 
 # Validating partition is in correct format
 def validate_partition_name(config):
-    pattern = r"^[A-Za-z0-9_\.]{1,79}$"
+    pattern = r"^[^()\<>*\$&?\|\[\]'\"`]{1,47}$"
     result = re.match(pattern, get_partition_name(config))
     if not bool(result):
         logger.error(f"validation failed: 'partition.name' value '{get_partition_name(config)}' have invalid format.")

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-dnf install -y python3-pip libxml2-devel libxslt-devel rust cargo python-devel libffi-devel
+dnf install -y python3-pip libxml2-devel libxslt-devel rust cargo python-devel libffi-devel mkisofs
 dnf groupinstall -y "Development Tools"
 pip install uv
 


### PR DESCRIPTION
- Change the logic of storing updated cloud init iso, currently its stored in update-config dir itself where the files of the ISO resides, its causing failure in write in certain situation since its trying to bundle the files and write into same dir. Hence moved the iso to diff dir on the lines of existing iso dir.
- Fix empty auth json passed during upgrade scenarios, it needs to be in json format, hence passing an empty json if user does nt provide one instead of empty string.
- Fix partition name's regex, seems current regex is to handle the vopt name, but partition name itself allows many other chars and length, hence changed the partition regex and used different logic to build the vopt name for cloud init similar to bootstrap vopt.
- In case of rerun scenario need to decide whether cloud init vopt need to be reuploaded or skipped based on partition's current status
  - If it is running, that means cloud init might have already attached to the partition, currently improper VIOS id is returned, fixed that with a check
  - If it is not running need to remove scsi mapping and dev if it is already attached. Currently it was not happening properly with the looping mechanism followed, now separated the removal and upload part to keep things simpler
- Add more debug logs